### PR TITLE
Apply page-coherence standard: fix checklists styling outlier

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,9 +44,15 @@ quarto render
 
 ### Page archetypes & styling
 
-- **Landing pages** (home, blog, about, every `projects/*/index.qmd`): plain title block — never `title-block-banner` (renders in `$primary`, stacking a second blue band directly under the already-blue navbar); no `date` or `categories` (those signal "article" and render a dated byline); `page-layout: full` only on the home page (hero); body must not repeat the frontmatter `title` as a `#` heading.
+- **Landing pages** (home, blog, about, every `projects/*/index.qmd`):
+  - Plain title block — never `title-block-banner` (renders in `$primary`, stacking a second blue band directly under the already-blue navbar)
+  - No `date` or `categories` (those signal "article" and render a dated byline)
+  - `page-layout: full` only on the home page (hero)
+  - Body must not repeat the frontmatter `title` as a `#` heading
 - **Article pages** (blog posts, individual checklists like `projects/checklists/investing.qmd`): keep `date` and `categories`; per-page `toc-title` is allowed.
 - **TOC rule (both archetypes):** global `toc: true` in `_quarto.yml` stays — TOC renders on the right for any page with headings. Never set `toc-location: left`; don't add per-page `toc: false`.
+
+### Posts & files
 
 - Blog posts go in `posts/YYYY-MM-DD-slug/index.qmd` (or `.ipynb` for notebook posts)
 - Posts need frontmatter: title, description, author, date, categories

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,12 @@ quarto render
 
 ## Content Conventions
 
+### Page archetypes & styling
+
+- **Landing pages** (home, blog, about, every `projects/*/index.qmd`): plain title block — never `title-block-banner` (renders in `$primary`, stacking a second blue band directly under the already-blue navbar); no `date` or `categories` (those signal "article" and render a dated byline); `page-layout: full` only on the home page (hero); body must not repeat the frontmatter `title` as a `#` heading.
+- **Article pages** (blog posts, individual checklists like `projects/checklists/investing.qmd`): keep `date` and `categories`; per-page `toc-title` is allowed.
+- **TOC rule (both archetypes):** global `toc: true` in `_quarto.yml` stays — TOC renders on the right for any page with headings. Never set `toc-location: left`; don't add per-page `toc: false`.
+
 - Blog posts go in `posts/YYYY-MM-DD-slug/index.qmd` (or `.ipynb` for notebook posts)
 - Posts need frontmatter: title, description, author, date, categories
 - Draft posts use `draft: true` in frontmatter — by default Quarto renders them as empty pages everywhere (even in `quarto preview`). To preview drafts locally, use the drafts profile: `QUARTO_PROFILE=drafts quarto preview` (defined in `_quarto-drafts.yml`). Never flip `draft: false` just to preview.

--- a/projects/checklists/did.qmd
+++ b/projects/checklists/did.qmd
@@ -7,7 +7,6 @@ aliases:
   - /checklists/difference-in-differences.html
 toc: true
 toc-title: Checklist Sections
-toc-location: left
 format:
   html:
     code-fold: true

--- a/projects/checklists/index.qmd
+++ b/projects/checklists/index.qmd
@@ -1,14 +1,8 @@
 ---
 title: "Checklists for Decision Making and Analysis"
 description: "A collection of curated checklists for various domains including investing and research methodologies."
-date: 2024-07-04
 aliases:
   - /checklists.html
-categories: [Checklists, Decision Making, Analysis]
-toc: true
-toc-location: left
-page-layout: full
-title-block-banner: true
 listing:
   id: listing-listing
   contents:
@@ -22,8 +16,6 @@ listing:
   fields: [title, description, categories]
   feed: false
 ---
-
-# Checklists for Decision Making and Analysis
 
 Checklists are powerful tools for ensuring consistency, completeness, and quality in complex processes. They help reduce errors, improve efficiency, and provide a systematic approach to decision-making and analysis. This page serves as an index for various checklists I've compiled and refined over time.
 

--- a/projects/checklists/investing.qmd
+++ b/projects/checklists/investing.qmd
@@ -7,7 +7,6 @@ aliases:
   - /checklists/investing.html
 toc: true
 toc-title: Checklist Sections
-toc-location: left
 format:
   html:
     code-fold: true


### PR DESCRIPTION
Implements the approved spec `docs/superpowers/specs/2026-06-11-page-coherence-standard-design.md` (Codex xhigh: SOUND ENOUGH TO IMPLEMENT, 2026-06-11).

## Changes
- **`projects/checklists/index.qmd`** — now a clean landing page: removed `title-block-banner` (the doubled blue band under the navbar), `date`, `categories`, `page-layout: full`, per-page TOC overrides, and the duplicate body `#` title. Matches the physics-quals landing shape.
- **`projects/checklists/investing.qmd`, `did.qmd`** — removed `toc-location: left`; TOC now renders on the default right like every other article page.
- **`CLAUDE.md`** — documented the two-archetype (landing vs article) styling standard under Content Conventions.

## Verification
- `quarto render` passes (49/49 pages).
- Rendered checklists index: no banner, no byline, single `<h1>`, right-side 3-item TOC identical in shape to physics-quals.
- `investing.html`/`did.html`: right TOC, no left-sidebar markup.
- Alias redirect stubs (`/checklists.html`, `/checklists/*.html`) still generated.
- Listing still renders both checklists with category tags.

Review trail (spec-compliance + code-quality subagent reviews, Codex xhigh final review) follows in comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)